### PR TITLE
T5471 - Ativar TimeLine modulo OCA/Project

### DIFF
--- a/project_timeline/__manifest__.py
+++ b/project_timeline/__manifest__.py
@@ -11,7 +11,8 @@
     "author": "Tecnativa, Onestein, "
               "Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "installable": False,
+    "installable": True,
+    'auto_install': False,
     "depends": [
         "project",
         "web_timeline",

--- a/project_timeline_hr_timesheet/__manifest__.py
+++ b/project_timeline_hr_timesheet/__manifest__.py
@@ -17,6 +17,6 @@
         'templates/assets.xml',
         'views/project_task_view.xml'
     ],
-    'installable': False,
+    'installable': True,
     'auto_install': False,
 }

--- a/project_timeline_task_dependency/__manifest__.py
+++ b/project_timeline_task_dependency/__manifest__.py
@@ -16,6 +16,6 @@
     'data': [
         'views/project_task_view.xml'
     ],
-    'installable': False,
+    'installable': True,
     'auto_install': False
 }


### PR DESCRIPTION
# Descrição

[IMP] Habilita instalação do TimeLine dos Projetos

- Modulos: project_timeline, project_timeline_hr_timesheet e
  project_timeline_task_dependency

# Informações adicionais

Dados da tarefa: [T5471](https://multi.multidadosti.com.br/web?#id=5880&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)
