### PR TITLE
T5975 - Melhorias nas Subtarefas do Projeto

### DIFF
--- a/project_task_dependency/__manifest__.py
+++ b/project_task_dependency/__manifest__.py
@@ -15,6 +15,6 @@
     'data': [
         'views/project_task_view.xml'
     ],
-    'installable': True,
+    'installable': False,
     'auto_install': False,
 }

--- a/project_timeline_task_dependency/__manifest__.py
+++ b/project_timeline_task_dependency/__manifest__.py
@@ -16,6 +16,6 @@
     'data': [
         'views/project_task_view.xml'
     ],
-    'installable': True,
+    'installable': False,
     'auto_install': False
 }


### PR DESCRIPTION
# Descrição

- [IMP] Bloqueia a opção de instalar módulos da OCA

# Informações adicionais

- [T5975](https://multi.multidados.tech/web#id=6384&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PRs relacionados:
- [core](https://github.com/multidadosti-erp/odoo/pull/146)
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/800)
- [private-addons](https://github.com/multidadosti-erp/multidadosti-private-addons/pull/690)
- [public-addons](https://github.com/multidadosti-erp/multidadosti-addons/pull/600)