### PR TITLE
T7615 - Ao Incluir o Milestone na tarefa, preencher a data final caso esteja em branco

### DIFF
--- a/project_milestone/models/project_task.py
+++ b/project_milestone/models/project_task.py
@@ -6,12 +6,17 @@ from odoo import models, fields, api
 class ProjectTask(models.Model):
     _inherit = 'project.task'
 
-    milestone_id = fields.Many2one('project.milestone',
-                                   string="Milestones",
-                                   group_expand='_read_group_milestone_ids',
-                                   domain="[('project_id', '=', project_id)]")
-    use_milestones = fields.Boolean(related='project_id.use_milestones',
-                                    help="Does this project use milestones?")
+    milestone_id = fields.Many2one(
+        'project.milestone',
+        string="Milestones",
+        group_expand='_read_group_milestone_ids',
+        domain="[('project_id', '=', project_id)]"
+    )
+
+    use_milestones = fields.Boolean(
+        related='project_id.use_milestones',
+        help="Does this project use milestones?"
+    )
 
     @api.model
     def _read_group_milestone_ids(self, milestone_ids, domain, order):
@@ -19,3 +24,11 @@ class ProjectTask(models.Model):
             milestone_ids = self.env['project.milestone'].search([(
                 'project_id', '=', self.env.context['default_project_id'])])
         return milestone_ids
+
+    @api.onchange('milestone_id')
+    def onchange_tax_id(self):
+        """ Método onchange que altera a data final da tarefa de acordo
+            com a data do milestone.
+        """
+        if self.milestone_id and self.date_deadline is False:
+            self.date_deadline = self.milestone_id.target_date


### PR DESCRIPTION
# Descrição

Adiciona onchange 'milestone_id' módulo 'project_milestone'
- Onchange para popular a data final da tarefa caso vazia.

# Informações adicionais

Dados da tarefa: [T7615 ](https://multi.multidados.tech/web?debug#id=8024&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)
