### PR TITLE
T7686 - Adicionar no Cadastro do Projeto: Key Users e Visão das Dependências

### DIFF
--- a/project_task_dependency/__manifest__.py
+++ b/project_task_dependency/__manifest__.py
@@ -10,7 +10,8 @@
     'author': "Onestein,Odoo Community Association (OCA)",
     'license': 'AGPL-3',
     'depends': [
-        'project'
+        'project',
+        'project_stage_state',
     ],
     'data': [
         'views/project_task_view.xml'

--- a/project_task_dependency/i18n/project_task_dependency.pot
+++ b/project_task_dependency/i18n/project_task_dependency.pot
@@ -122,3 +122,22 @@ msgstr ""
 msgid "You cannot create recursive dependencies between tasks."
 msgstr ""
 
+#. module: project_task_dependency
+#: model:ir.model.fields,help:project_task_dependency.field_project_task__dependency_open_task_count
+msgid "Tasks with open dependencies"
+msgstr ""
+
+#. module: project_task_dependency
+#: model:ir.model.fields,field_description:project_task_dependency.field_project_task__dependency_open_task_count
+msgid "Dependency Open Count"
+msgstr ""
+
+#. module: project_task_dependency
+#: model:ir.actions.act_window,name:project_task_dependency.action_dependency_tasks
+msgid "Dependency Tasks"
+msgstr ""
+
+#. module: project_task_dependency
+#: model_terms:ir.ui.view,arch_db:project_task_dependency.view_task_form2
+msgid "Closed"
+msgstr ""

--- a/project_task_dependency/i18n/pt_BR.po
+++ b/project_task_dependency/i18n/pt_BR.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-29 12:26+0000\n"
-"PO-Revision-Date: 2023-06-29 12:26+0000\n"
+"POT-Creation-Date: 2023-07-31 18:08+0000\n"
+"PO-Revision-Date: 2023-07-31 18:08+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -30,6 +30,16 @@ msgstr "Criado em"
 #: model_terms:ir.ui.view,arch_db:project_task_dependency.view_task_form2
 msgid "Dependencies"
 msgstr "Dependências"
+
+#. module: project_task_dependency
+#: model:ir.model.fields,field_description:project_task_dependency.field_project_task__dependency_open_task_count
+msgid "Dependency Open Count"
+msgstr "Qtde Dependência"
+
+#. module: project_task_dependency
+#: model:ir.actions.act_window,name:project_task_dependency.action_dependency_tasks
+msgid "Dependency Tasks"
+msgstr "Tarefas de Dependência"
 
 #. module: project_task_dependency
 #: model:ir.model.fields,field_description:project_task_dependency.field_project_task__depending_task_ids
@@ -97,7 +107,7 @@ msgid "Recursive Depending Tasks"
 msgstr "Tarefas Recursivas Dependente"
 
 #. module: project_task_dependency
-#: code:addons/project_task_dependency/models/project_task.py:98
+#: code:addons/project_task_dependency/models/project_task.py:110
 #: model:ir.model,name:project_task_dependency.model_project_task
 #, python-format
 msgid "Task"
@@ -114,7 +124,17 @@ msgid "Tasks that are dependent on this task."
 msgstr "Tarefas dependentes dessa tarefa."
 
 #. module: project_task_dependency
-#: code:addons/project_task_dependency/models/project_task.py:82
+#: model:ir.model.fields,help:project_task_dependency.field_project_task__dependency_open_task_count
+msgid "Tasks with open dependencies"
+msgstr "Tarefas com dependências abertas"
+
+#. module: project_task_dependency
+#: code:addons/project_task_dependency/models/project_task.py:94
 #, python-format
 msgid "You cannot create recursive dependencies between tasks."
 msgstr "Você não pode criar dependências recursivas entre tarefas."
+
+#. module: project_task_dependency
+#: model_terms:ir.ui.view,arch_db:project_task_dependency.view_task_form2
+msgid "Closed"
+msgstr "Fechada"

--- a/project_task_dependency/views/project_task_view.xml
+++ b/project_task_dependency/views/project_task_view.xml
@@ -16,10 +16,11 @@
                             <field name="user_id"/>
                             <field name="date_deadline"/>
                             <field name="stage_id"/>
-                            
+                            <field name="closed" string="Closed"/>
+
                             <button name="button_open_task"
                                     type="object" title="Open Task"
-                                    icon="fa-arrow-right"
+                                    icon="fa-window-restore"
                                     aria-label="Open Task"
                                     class="btn-link"/>
                         </tree>
@@ -27,5 +28,34 @@
                 </page>
             </xpath>
         </field>
+    </record>
+
+    <record id="view_task_kanban" model="ir.ui.view">
+        <field name="name">project.task.kanban</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.view_task_kanban"/>
+        <field name="arch" type="xml">
+            <field name="color" position="after">
+                <field name="dependency_open_task_count"/>
+            </field>
+
+            <xpath expr="//div[hasclass('oe_kanban_bottom_left')]" position="inside">
+                <div class="pull-right" groups="base.group_user" style="margin-left: 10px;">
+                    <t attrs="{'invisible': [('dependency_open_task_count', '=', 0)]}">
+                        <a type="object" name="button_action_dependency_tasks" style="font-weight:bold;color:orange">
+                            <span class="fa fa-exclamation-triangle fa-lg"/>
+                            <span><field name="dependency_open_task_count"/></span>
+                        </a>
+                    </t>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="action_dependency_tasks" model="ir.actions.act_window">
+        <field name="name">Dependency Tasks</field>
+        <field name="res_model">project.task</field>
+        <field name="view_mode">kanban,tree,form,calendar,pivot,graph,activity</field>
+        <field name="search_view_id" ref="project.view_task_search_form"/>
     </record>
 </odoo>


### PR DESCRIPTION
# Descrição

Adiciona no KanBan Inf. das Tarefas Dependêntes módulo 'project_task_dependency'

- Adiciona dependência do módulo 'project_stage_state' para controlar as tarefas finalizadas
- Atualiza tradução pt_br do módulo

# Informações adicionais

Dados da tarefa: [T7686](https://multi.multidados.tech/web?debug#id=8095&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver):
[1272](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1272)
